### PR TITLE
fix: remove unused console.log

### DIFF
--- a/src/mnb.ts
+++ b/src/mnb.ts
@@ -75,5 +75,3 @@ export async function getHistoricalRates(startDate: string, endDate: string, cur
 
 	return history;
 }
-
-getMnbRates().then((d) => console.log(d));


### PR DESCRIPTION
Because of the console.log, if you use it on a google cloud server, all cloud functions will unnecessarily call and console the result.